### PR TITLE
refactor: Move config code to its own module

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -4,8 +4,8 @@ use std::fs;
 
 #[derive(Deserialize)]
 pub struct Config {
-    server: String,
-    access_token: String,
+    pub server: String,
+    pub access_token: String,
 }
 
 impl Config {
@@ -17,13 +17,5 @@ impl Config {
             .expect(format!("Something went wrong reading the file {:?}", &config_path).as_str());
 
         toml::from_str(&config_string).expect("Could not parse the config")
-    }
-
-    pub fn server(&self) -> &String {
-        &self.server
-    }
-
-    pub fn access_token(&self) -> &String {
-        &self.access_token
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,29 @@
+use dirs::home_dir;
+use serde::Deserialize;
+use std::fs;
+
+#[derive(Deserialize)]
+pub struct Config {
+    server: String,
+    access_token: String,
+}
+
+impl Config {
+    pub fn parse_from_disk() -> Config {
+        let config_path = home_dir()
+            .expect("Could not find home dir")
+            .join(".config/gitlab.toml");
+        let config_string = fs::read_to_string(&config_path)
+            .expect(format!("Something went wrong reading the file {:?}", &config_path).as_str());
+
+        toml::from_str(&config_string).expect("Could not parse the config")
+    }
+
+    pub fn server(&self) -> &String {
+        &self.server
+    }
+
+    pub fn access_token(&self) -> &String {
+        &self.access_token
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -159,7 +159,7 @@ fn main() {
     if let Some(matches) = matches.subcommand_matches("get") {
         let namespace = matches.value_of("namespace").unwrap_or("");
         let config = Config::parse_from_disk();
-        let _ = Gitlab::new(config.server(), config.access_token())
+        let _ = Gitlab::new(&config.server, &config.access_token)
             .map_err(|err| {
                 println!("err {}", err);
                 err


### PR DESCRIPTION
Fixes #4 

I've used getter functions as I understand Config is a read only struct that must be built once using some parsing process.